### PR TITLE
Update INSTALL.md instructions for OS X 10.13.3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,7 +81,8 @@ Using homebrew:
 
 ```sh
 brew install git
-brew install curl --with-ssl --with-libssh2
+brew install curl --with-libssh2
+brew install brotli
 brew install git-ftp
 ```
 


### PR DESCRIPTION
Current installation instructions will not work on OS X without first running ```brew install brotli```. 

Users will experience the following without that command:

```
dyld: Library not loaded: /usr/local/opt/brotli/lib/libbrotlidec.1.dylib
  Referenced from: /usr/local/Cellar/git-ftp/1.4.0_5/libexec/bin/curl
  Reason: image not found
```

In addition, when running ``` brew install curl --with-ssl --with-libssh2```, users will get the following:

```
Warning: curl: this formula has no --with-ssl option so it will be ignored!
```
So it's removed from the file.